### PR TITLE
Don't hardcode /app

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,7 +7,7 @@ dependencies:
 
 web:
   commands:
-    start: "PM2_HOME=/app/run pm2 start index.js --no-daemon"
+    start: "PM2_HOME=$PLATFORM_APP_DIR/run pm2 start index.js --no-daemon"
     #in this setup you will find your application stdout and stderr in /app/run/logs
   locations:
     "/public":


### PR DESCRIPTION
Tested on PS. We don't guarantee `/app` as an absolute path, as far as I know. And this would allow you to run the app more easily in other environments, e.g. on local.