### PR TITLE
Add default port settings for running locally without Platform env

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 // Load the http module to create an http server.
+var DEFAULT_PORT = 8000;
+
 var http = require('http');
 var config= require("platformsh").config();
 
@@ -7,4 +9,4 @@ var server = http.createServer(function (request, response) {
   response.end("<html><head><title>Hello node</title></head><body><h1><img src='public/js.png'>Hello Node</h1><h3>Platform configuration:</h3><pre>"+JSON.stringify(config, null, 4) + "</pre></body></html>");
 });
 
-server.listen(config.port);
+server.listen(config.port || DEFAULT_PORT);


### PR DESCRIPTION
This patch enables running the sample project locally with `node index.js`.